### PR TITLE
Update `webpack-dev-server` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install
 Development:
 ```sh
 $ npm run dev
-$ open http://localhost:3000 # run in a separate terminal tab/window
+$ open http://localhost:8080 # run in a separate terminal tab/window
 ```
 
 Production:

--- a/app.js
+++ b/app.js
@@ -46,6 +46,9 @@ app.use(express.static(path.join(__dirname, 'public')));
 // properties that are local variables within the application
 // http://expressjs.com/en/api.html#app.locals
 app.locals.isProduction = isProduction;
+if (!isProduction) {
+    app.locals.publicPath = require('./webpack/development.config').output.publicPath;
+}
 
 /**
  * Routes.

--- a/bin/www
+++ b/bin/www
@@ -12,7 +12,7 @@ var http = require('http');
 /**
  * Get port from environment and store in Express.
  */
-var port = normalizePort(process.env.PORT || '3000');
+var port = normalizePort(process.env.PORT || '8080');
 app.set('port', port);
 
 /**

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Mark <mark@remarkablemark.org>",
   "scripts": {
     "start": "webpack --config webpack/production.config.js && NODE_ENV=production node bin/www",
-    "dev": "npm run hmr & nodemon bin/www",
-    "hmr": "webpack-dev-server --hot --config webpack/development.config.js"
+    "dev": "npm run wds & nodemon bin/www",
+    "wds": "webpack-dev-server --config webpack/development.config.js"
   },
   "dependencies": {
     "babel-core": "^6.7.6",

--- a/views/Layout.jsx
+++ b/views/Layout.jsx
@@ -13,22 +13,22 @@ module.exports = React.createClass({
 
     getDefaultProps: function() {
         return {
-            isProduction: true
+            isProduction: true,
+            publicPath: ''
         };
     },
 
     render: function() {
-        var publicPath = this.props.isProduction ? '' : 'http://localhost:3001/public';
         return (
             <html>
                 <head>
                     <meta charSet='utf-8' />
                     <title>{this.props.title}</title>
-                    <link rel='stylesheet' href={publicPath + '/css/style.css'} />
+                    <link rel='stylesheet' href={this.props.publicPath + '/css/style.css'} />
                 </head>
                 <body>
                     {this.props.children}
-                    <script src={publicPath + '/js/script.js'} />
+                    <script src={this.props.publicPath + '/js/script.js'} />
                 </body>
             </html>
         );

--- a/webpack/development.config.js
+++ b/webpack/development.config.js
@@ -7,7 +7,9 @@ var webpack = require('webpack');
 var path = require('path');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-var PORT = 3001;
+var PORT = 8081;
+var HOST = process.env.IP || 'localhost';
+var URL = 'http://' + HOST + ':' + 8081;
 
 /**
  * Webpack development configuration.
@@ -16,16 +18,16 @@ module.exports = {
     context: path.join(__dirname, '../src'),
 
     entry: [
-        'webpack-dev-server/client?http://localhost:' + PORT, // WebpackDevServer host and port
+        './js/script.js', // app entry point
         'webpack/hot/only-dev-server', // "only" prevents reload on syntax errors
-        './js/script.js' // app entry point
+        'webpack-dev-server/client?' + URL // WebpackDevServer host and port
         //path.join(__dirname, '../src/js/script.js')
     ],
 
     output: {
         path: path.join(__dirname, '../public/'),
         filename: './js/script.js',
-        publicPath: 'http://localhost:' + PORT + '/public/'
+        publicPath: URL + '/public'
     },
 
     debug: true,
@@ -66,9 +68,11 @@ module.exports = {
         })
     ],
 
+    // https://webpack.github.io/docs/webpack-dev-server.html
     devServer: {
         quiet: true, // don't output anything to the console
         inline: true, // embed the WebpackDevServer runtime into the bundle
+        host: HOST,
         port: PORT
     }
 };

--- a/webpack/development.config.js
+++ b/webpack/development.config.js
@@ -62,6 +62,7 @@ module.exports = {
     },
 
     plugins: [
+        new webpack.HotModuleReplacementPlugin(),
         new webpack.NoErrorsPlugin(),
         new ExtractTextPlugin('css/style.css', {
             allChunks: true
@@ -72,6 +73,7 @@ module.exports = {
     devServer: {
         quiet: true, // don't output anything to the console
         inline: true, // embed the WebpackDevServer runtime into the bundle
+        hot: true,
         host: HOST,
         port: PORT
     }


### PR DESCRIPTION
#### Tasks:
- Change main server's default port to `8080`
- Update `devServer` port to `8081`
- Update `devServer` host to `process.env.IP` and fallback to `localhost`
- Set `publicPath` in `app.locals.publicPath` (Express)
- Update `<Layout>` to use `publicPath` as a prop (default/production is `''`)
- Rename npm script `hmr` to `wds`
- Remove `--hot` flag in npm script `wds` and specify in `webpack/development.config.js`
