### PR TITLE
Use Require.js to load modules on client-side (in production)

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ var express = require('express');
 var ReactEngine = require('react-engine');
 var path = require('path');
 var bodyParser = require('body-parser');
+var dependencies = require('./package').dependencies;
 
 var app = express();
 // `process.env.NODE_ENV`, default is "development"
@@ -40,6 +41,13 @@ app.use(express.static(path.join(__dirname, 'build')));
 // properties that are local variables within the application
 // http://expressjs.com/en/api.html#app.locals
 app.locals.isProduction = isProduction;
+function cleanVersion(v) { return v.replace(/^\D/, ''); }
+app.locals.versions = {
+    'react': cleanVersion(dependencies['react']),
+    'react-dom': cleanVersion(dependencies['react-dom']),
+    'react-router': cleanVersion(dependencies['react-router'])
+};
+
 if (!isProduction) {
     app.locals.publicPath = require('./webpack/development.config').output.publicPath;
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -3,6 +3,16 @@ require('../css/style.css');
 (function(window, document){
     'use strict';
 
+    // config
+    try {
+        var config = JSON.parse(
+            document.getElementById('data-config').getAttribute('data-config')
+        );
+        var versions = config.versions;
+    } catch (error) {
+        // console.log(error);
+    }
+
     /**
      * Client-side mounting.
      */

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -31,16 +31,22 @@ require('../css/style.css');
     });
 
     /**
-     * Client-side mounting.
+     * Mount on client-side.
      */
-    document.addEventListener('DOMContentLoaded', function() {
-        var client = require('react-engine/lib/client');
+    requirejs(['react', 'react-dom'], function(React, ReactDOM) {
+        window.React = React;
+        window.ReactDOM = ReactDOM;
 
-        client.boot({
-            routes: require('../../routes/Routes'),
-            viewResolver: function(viewName) {
-                return require('../../views/' + viewName);
-            }
+        requirejs(['react-router'], function(ReactRouter) {
+            window.ReactRouter = ReactRouter;
+
+            var client = require('react-engine/lib/client');
+            client.boot({
+                routes: require('../../routes/Routes'),
+                viewResolver: function(viewName) {
+                    return require('../../views/' + viewName);
+                }
+            });
         });
     });
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,6 @@
 require('../css/style.css');
 
-(function(window, document){
+(function(window, document, requirejs, define){
     'use strict';
 
     // config
@@ -12,6 +12,23 @@ require('../css/style.css');
     } catch (error) {
         // console.log(error);
     }
+
+    /**
+     * Require.js config.
+     */
+    requirejs.config({
+        paths: {
+            'react': [
+                '//cdnjs.cloudflare.com/ajax/libs/react/' + versions['react'] + '/react.min'
+            ],
+            'react-dom': [
+                '//cdnjs.cloudflare.com/ajax/libs/react/' + versions['react-dom'] + '/react-dom.min'
+            ],
+            'react-router': [
+                '//cdnjs.cloudflare.com/ajax/libs/react-router/' + versions['react-router'] + '/ReactRouter.min'
+            ]
+        }
+    });
 
     /**
      * Client-side mounting.
@@ -26,4 +43,5 @@ require('../css/style.css');
             }
         });
     });
-})(window, document);
+
+})(window, document, window.requirejs, window.define);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,6 +8,7 @@ require('../css/style.css');
         var config = JSON.parse(
             document.getElementById('data-config').getAttribute('data-config')
         );
+        var isProduction = config.isProduction;
         var versions = config.versions;
     } catch (error) {
         // console.log(error);
@@ -33,21 +34,33 @@ require('../css/style.css');
     /**
      * Mount on client-side.
      */
-    requirejs(['react', 'react-dom'], function(React, ReactDOM) {
-        window.React = React;
-        window.ReactDOM = ReactDOM;
+    function boot() {
+        var client = require('react-engine/lib/client');
+        client.boot({
+            routes: require('../../routes/Routes'),
+            viewResolver: function(viewName) {
+                return require('../../views/' + viewName);
+            }
+        });
+    }
 
-        requirejs(['react-router'], function(ReactRouter) {
-            window.ReactRouter = ReactRouter;
+    // load modules via Require.js on production
+    if (isProduction) {
+        requirejs(['react', 'react-dom'], function(React, ReactDOM) {
+            window.React = React;
+            window.ReactDOM = ReactDOM;
 
-            var client = require('react-engine/lib/client');
-            client.boot({
-                routes: require('../../routes/Routes'),
-                viewResolver: function(viewName) {
-                    return require('../../views/' + viewName);
-                }
+            requirejs(['react-router'], function(ReactRouter) {
+                window.ReactRouter = ReactRouter;
+                boot();
             });
         });
-    });
+
+    // load modules via WebpackDevServer on development
+    } else {
+        document.addEventListener('DOMContentLoaded', function() {
+            boot();
+        });
+    }
 
 })(window, document, window.requirejs, window.define);

--- a/views/Layout.jsx
+++ b/views/Layout.jsx
@@ -21,7 +21,7 @@ module.exports = React.createClass({
 
     render: function() {
         var config = {
-            isProduction: true,
+            isProduction: this.props.isProduction,
             versions: this.props.versions
         };
         return (

--- a/views/Layout.jsx
+++ b/views/Layout.jsx
@@ -14,11 +14,16 @@ module.exports = React.createClass({
     getDefaultProps: function() {
         return {
             isProduction: true,
-            publicPath: ''
+            publicPath: '',
+            versions: {}
         };
     },
 
     render: function() {
+        var config = {
+            isProduction: true,
+            versions: this.props.versions
+        };
         return (
             <html>
                 <head>
@@ -28,6 +33,7 @@ module.exports = React.createClass({
                 </head>
                 <body>
                     {this.props.children}
+                    <div id='data-config' data-config={JSON.stringify(config)} />
                     <script src={this.props.publicPath + '/js/main.js'} />
                 </body>
             </html>

--- a/views/Layout.jsx
+++ b/views/Layout.jsx
@@ -34,6 +34,7 @@ module.exports = React.createClass({
                 <body>
                     {this.props.children}
                     <div id='data-config' data-config={JSON.stringify(config)} />
+                    <script src='//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.1/require.min.js' />
                     <script src={this.props.publicPath + '/js/main.js'} />
                 </body>
             </html>

--- a/webpack/production.config.js
+++ b/webpack/production.config.js
@@ -68,5 +68,11 @@ module.exports = {
                 warnings: false
             }
         })
-    ]
+    ],
+
+    externals: {
+        'react': 'React',
+        'react-dom': 'ReactDOM',
+        'react-router': 'ReactRouter'
+    }
 };


### PR DESCRIPTION
#### Tasks:
- Expose package versions from `package.json` in `app.locals.versions`:
  - react
  - react-dom
  - react-router
- Create a placeholder `<div>` that contains the versions and other config (`isProduction`) in a data attribute (`data-config`)
  - This is necessary because `__REACT_ENGINE__` JSON data is not accessible until `DOMContentLoaded` and there's no reason to have Require.js wait until then (optimization)
  - Update `main.js` to get and parse the data config
- Add [Require.js](http://requirejs.org) to `<Layout>`
- Add the [CDN libraries](https://cdnjs.com) to [Require.js config](http://requirejs.org/docs/api.html#config)
  - Make sure to dynamically generate the url based on the package version (ensure version consistency with `package.json` modules)
- Do not bundle `react`, `react-dom`, and `react-router` in production build (webpack)
- Since `webpack-dev-server` serves the bundle for development, there's no reason to use Require.js in development (Require.js only used in production)

Resolves #5
