### PR TITLE
Optimize webpack build

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -17,24 +17,26 @@ require('../css/style.css');
     /**
      * Require.js config.
      */
-    requirejs.config({
-        paths: {
-            'react': [
-                '//cdnjs.cloudflare.com/ajax/libs/react/' + versions['react'] + '/react.min',
-                '//cdn.jsdelivr.net/react/' + versions['react'] + '/react.min',
-                '//unpkg.com/react@' + versions['react'] + '/dist/react.min'
-            ],
-            'react-dom': [
-                '//cdnjs.cloudflare.com/ajax/libs/react/' + versions['react-dom'] + '/react-dom.min',
-                '//cdn.jsdelivr.net/react/' + versions['react-dom'] + '/react-dom.min',
-                '//unpkg.com/react-dom@' + versions['react-dom'] + '/dist/react-dom.min'
-            ],
-            'react-router': [
-                '//cdnjs.cloudflare.com/ajax/libs/react-router/' + versions['react-router'] + '/ReactRouter.min',
-                '//unpkg.com/react-router@' + versions['react-router'] + '/umd/ReactRouter.min'
-            ]
-        }
-    });
+    if (requirejs) {
+        requirejs.config({
+            paths: {
+                'react': [
+                    '//cdnjs.cloudflare.com/ajax/libs/react/' + versions['react'] + '/react.min',
+                    '//cdn.jsdelivr.net/react/' + versions['react'] + '/react.min',
+                    '//unpkg.com/react@' + versions['react'] + '/dist/react.min'
+                ],
+                'react-dom': [
+                    '//cdnjs.cloudflare.com/ajax/libs/react/' + versions['react-dom'] + '/react-dom.min',
+                    '//cdn.jsdelivr.net/react/' + versions['react-dom'] + '/react-dom.min',
+                    '//unpkg.com/react-dom@' + versions['react-dom'] + '/dist/react-dom.min'
+                ],
+                'react-router': [
+                    '//cdnjs.cloudflare.com/ajax/libs/react-router/' + versions['react-router'] + '/ReactRouter.min',
+                    '//unpkg.com/react-router@' + versions['react-router'] + '/umd/ReactRouter.min'
+                ]
+            }
+        });
+    }
 
     /**
      * Mount on client-side.

--- a/views/Layout.jsx
+++ b/views/Layout.jsx
@@ -34,7 +34,7 @@ module.exports = React.createClass({
                 <body>
                     {this.props.children}
                     <div id='data-config' data-config={JSON.stringify(config)} />
-                    <script src='//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.1/require.min.js' />
+                    {config.isProduction && <script src='//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.1/require.min.js' />}
                     <script src={this.props.publicPath + '/js/main.js'} />
                 </body>
             </html>

--- a/webpack/development.config.js
+++ b/webpack/development.config.js
@@ -62,6 +62,7 @@ module.exports = {
     },
 
     plugins: [
+        new webpack.optimize.OccurrenceOrderPlugin(),
         new webpack.HotModuleReplacementPlugin(),
         new webpack.NoErrorsPlugin(),
         new ExtractTextPlugin('css/style.css', {

--- a/webpack/production.config.js
+++ b/webpack/production.config.js
@@ -55,10 +55,10 @@ module.exports = {
             allChunks: true
         }),
 
+        // https://github.com/webpack/docs/wiki/optimization
+        new webpack.optimize.OccurrenceOrderPlugin(),
         new webpack.optimize.DedupePlugin(),
-
         new webpack.optimize.AggressiveMergingPlugin(),
-
         new webpack.optimize.UglifyJsPlugin({
             sourceMap: false,
             output: {

--- a/webpack/production.config.js
+++ b/webpack/production.config.js
@@ -73,6 +73,7 @@ module.exports = {
     externals: {
         'react': 'React',
         'react-dom': 'ReactDOM',
-        'react-router': 'ReactRouter'
+        'react-router': 'ReactRouter',
+        'history': true
     }
 };


### PR DESCRIPTION
#### Tasks:
- Add `history` to [externals](http://webpack.github.io/docs/configuration.html#externals) in `webpack/production.config.js`
  - `history` is required for `react-router` **v1** but since we're using **v2**, we no longer need to bundle it (see [source](https://github.com/paypal/react-engine/blob/8fd56aa95d9e2ec8ec60c4b542f6a6cce60e91bc/lib/client.js#L62))
  - This decreases minified bundle size from **24 kb** to **8.67 kb**
- Add [OccurrenceOrderPlugin](https://github.com/webpack/docs/wiki/optimization#minimize) to both webpack configs to optimize the module/chunk ids
- Use Require.js only in production (do not load in development)
