### PR TITLE
Add es2015 support

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -8,8 +8,9 @@
 // https://babeljs.io/docs/usage/require/
 require('babel-register')({
     // http://babeljs.io/docs/plugins/#presets
-    presets: ['react']
+    presets: ['react', 'es2015']
 });
+
 var app = require('../app');
 var debug = require('debug')('react-engine-template:server');
 var http = require('http');

--- a/webpack/development.config.js
+++ b/webpack/development.config.js
@@ -37,7 +37,7 @@ module.exports = {
     module: {
         loaders: [
             {
-                test: /\.jsx$/,
+                test: /\.jsx?$/,
                 exclude: /(node_modules|bower_components)/,
                 loader: 'babel-loader',
                 query: {

--- a/webpack/production.config.js
+++ b/webpack/production.config.js
@@ -26,7 +26,7 @@ module.exports = {
     module: {
         loaders: [
             {
-                test: /\.jsx$/,
+                test: /\.jsx?$/,
                 exclude: /(node_modules|bower_components)/,
                 loader: 'babel-loader',
                 query: {


### PR DESCRIPTION
#### Motivation:

Users may want to use [es2015](https://babeljs.io/docs/learn-es2015/) features in their server and client JavaScript files.
#### Tasks:
- **Server**: Add [es2015 preset](https://babeljs.io/docs/plugins/preset-es2015/) to `babel-register`
- **Client**: Update `babel-loader` in webpack to transpile and compile files with `.js` extension as well
