### PR TITLE
Add cachebust query to main stylesheet and script in production

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,6 +47,7 @@ app.locals.versions = {
     'react-dom': cleanVersion(dependencies['react-dom']),
     'react-router': cleanVersion(dependencies['react-router'])
 };
+app.locals.cachebust = Date.now().toString(36);
 
 if (!isProduction) {
     app.locals.publicPath = require('./webpack/development.config').output.publicPath;

--- a/views/Layout.jsx
+++ b/views/Layout.jsx
@@ -15,6 +15,7 @@ module.exports = React.createClass({
         return {
             isProduction: true,
             publicPath: '',
+            cachebust: '',
             versions: {}
         };
     },
@@ -24,18 +25,25 @@ module.exports = React.createClass({
             isProduction: this.props.isProduction,
             versions: this.props.versions
         };
+        var cachebust = (
+            this.props.isProduction ?
+            '?v=' + this.props.cachebust :
+            ''
+        );
         return (
             <html>
                 <head>
                     <meta charSet='utf-8' />
                     <title>{this.props.title}</title>
-                    <link rel='stylesheet' href={this.props.publicPath + '/css/style.css'} />
+                    <link rel='stylesheet'
+                          href={this.props.publicPath + '/css/style.css' + cachebust}
+                    />
                 </head>
                 <body>
                     {this.props.children}
                     <div id='data-config' data-config={JSON.stringify(config)} />
                     {config.isProduction && <script src='//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.1/require.min.js' />}
-                    <script src={this.props.publicPath + '/js/main.js'} />
+                    <script src={this.props.publicPath + '/js/main.js' + cachebust} />
                 </body>
             </html>
         );


### PR DESCRIPTION
#### Motivation:

When the app is deployed, user browsers may still be using the previously cached version of the static assets instead of the newly built one.

Thus, appended a unique id to the url as a querystring to cachebust the assets and make the browser download the updated version.
#### Tasks:
- Set `app.locals.cachebust` to a unique hash based on Date in production.
- Append the cachebust to the stylesheet and script url.
